### PR TITLE
Prefix ambiguity

### DIFF
--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -39,21 +39,28 @@ class Command:
         for command_plugin in plugin_list:
             command_plugin.setup(self, plugin)
 
-    def parse_command(self, string):
+    def parse_command(self, string, user=None):
+        prefix_char = self.plugin.get_settings().get(["prefix"])
         parts = re.split('\s+', string)
 
         prefix_len = len(self.plugin.get_settings().get(["prefix"]))
-        command = self.command_dict.get(parts[0][prefix_len:])
-        if command is None:
-            if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
-                    parts[0].lower() == "help":
-                return self.help()
-            return None, None
+        if parts[0][0] == prefix_char or user == "Dummy":
+            command_string = parts[0][prefix_len:]
+            command = self.command_dict.get(command_string)
+            if command is None:
+                if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
+                        parts[0].lower() == "help":
+                    return self.help()
+                return None, None
 
-        if command.get('params'):
-            return command['cmd'](parts)
-        else:
-            return command['cmd']()
+            if user and not self.check_perms(command_string, user):
+                return None, error_embed(author=self.plugin.get_printer_name(),
+                                         title="Permission Denied")
+
+            if command.get('params'):
+                return command['cmd'](parts)
+            else:
+                return command['cmd']()
 
     def timelapse(self):
 


### PR DESCRIPTION
Fixed 'parse_command' to check for matching prefix from settings. Bot would respond to any character, not the configured one. Also caused both of my bots to respond regardless of prefix setting.

Also added sanity check to see if it will pass Continuous Integration tests,

```python
if parts[0][0] == prefix_char or user == "Dummy":
```